### PR TITLE
Removed unused codes,add missing option

### DIFF
--- a/admin/options-page.php
+++ b/admin/options-page.php
@@ -218,6 +218,14 @@ class AnsPress_Options_Page
 				'value' => $settings['disable_comments_on_question'],
 				'show_desc_tip' => false,
 			) ,
+			array(
+				'name' => 'anspress_opt[show_title_in_question]',
+				'label' => __('Show title in question', 'ap') ,
+				'desc' => __('Show title of the question in question page.', 'ap') ,
+				'type' => 'checkbox',
+				'value' => $settings['show_title_in_question'],
+				'show_desc_tip' => false,
+			) ,
 		));
 		
 		// Register answer settings

--- a/includes/options.php
+++ b/includes/options.php
@@ -72,7 +72,6 @@ function ap_default_options(){
 		'show_social_login'		=> false,
 		'theme' 				=> 'default',
 		'author_credits' 		=> false,
-		'clear_database' 		=> false,
 		'minimum_qtitle_length'	=> 10,
 		'minimum_question_length'=> 10,
 		'multiple_answers' 		=> false,

--- a/theme/default/question.php
+++ b/theme/default/question.php
@@ -17,18 +17,11 @@ global $post;
 				<header class="ap-q-head">
 					<?php 
 						/**
-						 * ACTION: ap_before_question_title
-						 * @since 	2.0
-						 */
-						do_action('ap_before_question_title', $post);
-					?>
-					<?php 
-						/**
 						 * By default this title is hidden
 						 */
 						if(ap_opt('show_title_in_question')) : 
 					?>
-						<h1 class="entry-title"><a href="<?php get_permalink() ?>"><?php the_title(); ?></a></h1>
+						<h1 class="entry-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h1>
 					<?php endif; ?>
 
 					<?php 


### PR DESCRIPTION
clear_database is not needed anymore we have db_cleanup
show_title_in_question is missing the options code
removed POSTED IN CATEGORY as suggested [here](http://wp3.in/questions/question/2609/capitalized-posted-in-category-name/)
replace get with the for echo
///Edit:Because is failing and I don't know how to fix this just do the changes by your own and close the request if you can't merge it